### PR TITLE
signals: use new HermitCore signal handling syscalls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.creator*
+*.creator.user
+*.config
+*.files
+*.includes

--- a/newlib/libc/sys/hermit/kill.c
+++ b/newlib/libc/sys/hermit/kill.c
@@ -33,6 +33,7 @@
 #include <_syslist.h>
 #include <errno.h>
 #include "warning.h"
+#include "syscall.h"
 
 int
 _DEFUN (kill, (pid, sig),
@@ -57,16 +58,9 @@ _DEFUN (_kill_r, (ptr, pid, sig),
 		return -1;
 	}
 
-	if (ptr->_sig_func && ptr->_sig_func[sig])
-	{
-		_sig_func_ptr func = ptr->_sig_func[sig];
-
-		if (_getpid_r(ptr) == pid) {
-			func(sig);
-			return 0;
-		}
+	int ret = sys_kill(pid, sig);
+	if(ret) {
+		ptr->_errno = ret;
 	}
-
-	ptr->_errno = EINVAL;
-	return -1;
+	return ret;
 }

--- a/newlib/libc/sys/hermit/signal.c
+++ b/newlib/libc/sys/hermit/signal.c
@@ -16,7 +16,9 @@
 
 
 /*
- * Adapted by S. Lankes, RWTH Aachen University, for HermitCore.
+ * Adapted for HermitCore by:
+ *  - S. Lankes, RWTH Aachen University
+ *  - Daniel Krebs, RWTH Aachen University
  */
 
 #include <errno.h>
@@ -24,25 +26,28 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <reent.h>
+#include <malloc.h>
 #include <_syslist.h>
 
 int
 _DEFUN (_init_signal_r, (ptr),
 	struct _reent *ptr)
 {
-  int i;
+	int i;
 
-  if (ptr->_sig_func == NULL)
-    {
-      ptr->_sig_func = (_sig_func_ptr *)_malloc_r (ptr, sizeof (_sig_func_ptr) * NSIG);
-      if (ptr->_sig_func == NULL)
-	return -1;
+	if (ptr->_sig_func == NULL) {
+		ptr->_sig_func = (_sig_func_ptr *)_malloc_r (ptr, sizeof (_sig_func_ptr) * NSIG);
 
-      for (i = 0; i < NSIG; i++)
-	ptr->_sig_func[i] = SIG_DFL;
-    }
+		if (ptr->_sig_func == NULL) {
+			return -1;
+		}
 
-  return 0;
+		for (i = 0; i < NSIG; i++) {
+			ptr->_sig_func[i] = SIG_DFL;
+		}
+	}
+
+	return 0;
 }
 
 _sig_func_ptr
@@ -51,21 +56,21 @@ _DEFUN (_signal_r, (ptr, sig, func),
 	int sig _AND
 	_sig_func_ptr func)
 {
-  _sig_func_ptr old_func;
+	_sig_func_ptr old_func;
 
-  if (sig < 0 || sig >= NSIG)
-    {
-      ptr->_errno = EINVAL;
-      return SIG_ERR;
-    }
+	if (sig < 0 || sig >= NSIG) {
+		ptr->_errno = EINVAL;
+		return SIG_ERR;
+	}
 
-  if (ptr->_sig_func == NULL && _init_signal_r (ptr) != 0)
-    return SIG_ERR;
-  
-  old_func = ptr->_sig_func[sig];
-  ptr->_sig_func[sig] = func;
+	if (ptr->_sig_func == NULL && _init_signal_r (ptr) != 0) {
+		return SIG_ERR;
+	}
 
-  return old_func;
+	old_func = ptr->_sig_func[sig];
+	ptr->_sig_func[sig] = func;
+
+	return old_func;
 }
 
 int
@@ -94,13 +99,13 @@ _DEFUN (signal, (sig, func),
 	int sig _AND
 	_sig_func_ptr func)
 {
-  return _signal_r (_REENT, sig, func);
+	return _signal_r (_REENT, sig, func);
 }
 
 int 
 _DEFUN_VOID (_init_signal)
 {
-  return _init_signal_r (_REENT);
+	return _init_signal_r (_REENT);
 }
 
 #endif

--- a/newlib/libc/sys/hermit/signal.c
+++ b/newlib/libc/sys/hermit/signal.c
@@ -25,9 +25,49 @@
 #include <signal.h>
 #include <stddef.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <reent.h>
 #include <malloc.h>
 #include <_syslist.h>
+#include "syscall.h"
+
+/*
+ * Notes:
+ *	- man 2 sigreturn
+ *	- man 7 signal
+*/
+
+static void
+newlib_signal_dispatcher(int signum)
+{
+	// assume to be called in user context
+	struct _reent* reent = _REENT;
+
+	if (signum < 0 || signum >= NSIG) {
+		reent->_errno = EINVAL;
+		return;
+	}
+
+	if(reent->_sig_func == NULL) {
+		reent->_errno = ENOENT;
+		return;
+	}
+
+	_sig_func_ptr func = reent->_sig_func[signum];
+
+	if(func == SIG_DFL) {
+		fprintf(stderr, "Caught unhandled signal %d, terminating\n", signum);
+		// terminate if no signal handler registered
+		sys_exit(128 + signum);
+	} else if(func == SIG_IGN) {
+		// ignore
+	} else if(func == SIG_ERR) {
+		reent->_errno = EINVAL;
+	} else {
+		// finally call user code
+		func(signum);
+	}
+}
 
 int
 _DEFUN (_init_signal_r, (ptr),
@@ -45,6 +85,8 @@ _DEFUN (_init_signal_r, (ptr),
 		for (i = 0; i < NSIG; i++) {
 			ptr->_sig_func[i] = SIG_DFL;
 		}
+
+		sys_signal(newlib_signal_dispatcher);
 	}
 
 	return 0;

--- a/newlib/libc/sys/hermit/syscall.h
+++ b/newlib/libc/sys/hermit/syscall.h
@@ -57,6 +57,8 @@ extern "C" {
 struct sem;
 typedef struct sem sem_t;
 
+typedef void (*signal_handler_t)(int);
+
 /*
  * HermitCore is a libOS.
  * => classical system calls are realized as normal function
@@ -84,6 +86,12 @@ int sys_sem_cancelablewait(sem_t* sem, unsigned int ms);
 int sys_clone(tid_t* id, void* ep, void* argv);
 off_t sys_lseek(int fd, off_t offset, int whence);
 size_t sys_get_ticks(void);
+int sys_rcce_init(int session_id);
+size_t sys_rcce_malloc(int session_id, int ue);
+int sys_rcce_fini(int session_id);
+void sys_yield(void);
+int sys_kill(tid_t dest, int signum);
+int sys_signal(signal_handler_t handler);
 
 #define __NR_exit 		0
 #define __NR_write		1


### PR DESCRIPTION
This is the companion PR to https://github.com/RWTH-OS/HermitCore/pull/28. It makes use of the new HermitCore signal handling.

This also deprecates #1 which hasn't been merged to `hermit` branch anyway.
